### PR TITLE
Get section of screen with most green pixels

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Utilities/ConceptWebcam.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Utilities/ConceptWebcam.java
@@ -1,3 +1,32 @@
+/* Copyright (c) 2020 FIRST. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted (subject to the limitations in the disclaimer below) provided that
+ * the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this list
+ * of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice, this
+ * list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+ *
+ * Neither the name of FIRST nor the names of its contributors may be used to endorse or
+ * promote products derived from this software without specific prior written permission.
+ *
+ * NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS
+ * LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package org.firstinspires.ftc.teamcode.Utilities;
 
 import android.graphics.Bitmap;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Utilities/ConceptWebcam.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Utilities/ConceptWebcam.java
@@ -87,11 +87,11 @@ public class ConceptWebcam extends LinearOpMode {
      */
     private static final int secondsPermissionTimeout = Integer.MAX_VALUE;
 
-	/**
-	 * Sample size of the bitmap image, used to reduce computation time.
-	 * Large numbers decrease image quality.
-	*/
-	private int sampleSize = 4;
+    /**
+     * Sample size of the bitmap image, used to reduce computation time.
+     * Large numbers decrease image quality.
+    */
+    private int sampleSize = 4;
 
     /**
      * State regarding our interaction with the camera
@@ -180,21 +180,21 @@ public class ConceptWebcam extends LinearOpMode {
      */
     private void onNewFrame(Bitmap frame) {
 
-		// Get amount of green pixels in each section
-		int[] sections = get_majority_green(3, frame);
+        // Get amount of green pixels in each section
+        int[] sections = get_majority_green(3, frame);
 
-		int section = 0;
-		int section_size = 0;
+        int section = 0;
+        int section_size = 0;
 
-		// Get section with most green
-		for (int i = 0; i < sections.length; ++i) {
-			if (sections[i] > section_size) {
-				section = i;
-				section_size = sections[i];
-			} 
-		}
+        // Get section with most green
+        for (int i = 0; i < sections.length; ++i) {
+            if (sections[i] > section_size) {
+                section = i;
+                section_size = sections[i];
+            } 
+        }
 
-		System.out.println("Segment with the most green: " + section);
+        System.out.println("Segment with the most green: " + section);
 
         saveBitmap(frame);
         frame.recycle(); // not strictly necessary, but helpful
@@ -203,45 +203,46 @@ public class ConceptWebcam extends LinearOpMode {
 	/**
      * Get the segment of camera containing the most green
      */
-	private int[] get_majority_green(int segments, Bitmap frame) {
-		final BitmapFactory.Options options = new BitmapFactory.Options();
+    private int[] get_majority_green(int segments, Bitmap frame) {
+        final BitmapFactory.Options options = new BitmapFactory.Options();
 
-		// Reduce the resolution of the bitmap image
-		options.inSampleSize = this.sampleSize;
+        // Reduce the resolution of the bitmap image
+        options.inSampleSize = this.sampleSize;
 
-		// Get the image as a bitmap
-		Bitmap bmp = BitmapFactory.decodeResource(getResources(), R.drawable.image, options);
+        // Get the image as a bitmap
+        Bitmap bmp = BitmapFactory.decodeResource(getResources(), R.drawable.image, options);
 
-		// Get the image dimensions
-		int imageHeight = bmp.getHeight();
-		int imageWidth = bmp.getWidth();
+        // Get the image dimensions
+        int imageHeight = bmp.getHeight();
+        int imageWidth = bmp.getWidth();
 
-		// Divide the image into segments
-		int segment_length = imageWidth / segments;
+        // Divide the image into segments
+        int segment_length = imageWidth / segments;
 
-		// Array containing the total number of green pixels in a segment
-		int[] averages = new int[segments];
+        // Array containing the total number of green pixels in a segment
+        int[] averages = new int[segments];
 
-		for (int x = 0; x < imageWidth; x++) {
-			for (int y = 0; y < imageHeight; y++) {
+        for (int x = 0; x < imageWidth; x++) {
+            for (int y = 0; y < imageHeight; y++) {
 
-				// Get pixel at x, y coordinate
-				int pixel = bmp.getPixel(x, y);
+                // Get pixel at x, y coordinate
+                int pixel = bmp.getPixel(x, y);
 
-				// Get RGB values from hex
-				int r = pixel & 0xff;
-				int g = (pixel >> 8) & 0xff;
-				int b = (pixel >> 16) & 0xff;
+                // Get RGB values from hex
+                int r = pixel & 0xff;
+                int g = (pixel >> 8) & 0xff;
+                int b = (pixel >> 16) & 0xff;
 
-				// Get index in array
-				int index = x / segment_length;
+                // Get index in array
+                int index = x / segment_length;
 
-				// If pixel is green, add to array
-				if (g >= r && g >= b && index < segments) averages[index] += 1;
-			}
-		}
+                // If pixel is green, add to array
+                if (g >= r && g >= b && index < segments)
+                    averages[index] += 1;
+            }
+        }
 
-		return averages;
+        return averages;
     }
 
     //----------------------------------------------------------------------------------------------

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Utilities/ConceptWebcam.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Utilities/ConceptWebcam.java
@@ -87,7 +87,7 @@ public class ConceptWebcam extends LinearOpMode {
      */
     private static final int secondsPermissionTimeout = Integer.MAX_VALUE;
 
-    /**
+    /** TODO
      * Sample size of the bitmap image, used to reduce computation time.
      * Large numbers decrease image quality.
     */
@@ -203,14 +203,7 @@ public class ConceptWebcam extends LinearOpMode {
 	/**
      * Get the segment of camera containing the most green
      */
-    private int[] get_majority_green(int segments, Bitmap frame) {
-        final BitmapFactory.Options options = new BitmapFactory.Options();
-
-        // Reduce the resolution of the bitmap image
-        options.inSampleSize = this.sampleSize;
-
-        // Get the image as a bitmap
-        Bitmap bmp = BitmapFactory.decodeResource(getResources(), R.drawable.image, options);
+    private int[] get_majority_green(int segments, Bitmap bmp) {
 
         // Get the image dimensions
         int imageHeight = bmp.getHeight();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Utilities/ConceptWebcam.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Utilities/ConceptWebcam.java
@@ -1,35 +1,7 @@
-/* Copyright (c) 2020 FIRST. All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted (subject to the limitations in the disclaimer below) provided that
- * the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list
- * of conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this
- * list of conditions and the following disclaimer in the documentation and/or
- * other materials provided with the distribution.
- *
- * Neither the name of FIRST nor the names of its contributors may be used to endorse or
- * promote products derived from this software without specific prior written permission.
- *
- * NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS
- * LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
- * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
- * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 package org.firstinspires.ftc.teamcode.Utilities;
 
 import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.graphics.ImageFormat;
 import android.os.Handler;
 
@@ -86,6 +58,12 @@ public class ConceptWebcam extends LinearOpMode {
      */
     private static final int secondsPermissionTimeout = Integer.MAX_VALUE;
 
+	/**
+	 * Sample size of the bitmap image, used to reduce computation time.
+	 * Large numbers decrease image quality.
+	 */
+	private int sampleSize = 4;
+
     /**
      * State regarding our interaction with the camera
      */
@@ -137,7 +115,9 @@ public class ConceptWebcam extends LinearOpMode {
 
             telemetry.addData(">", "Press Play to start");
             telemetry.update();
+
             waitForStart();
+
             telemetry.clear();
             telemetry.addData(">", "Started...Press 'A' to capture frame");
 
@@ -170,8 +150,69 @@ public class ConceptWebcam extends LinearOpMode {
      * Do something with the frame
      */
     private void onNewFrame(Bitmap frame) {
+
+		// Get amount of green pixels in each section
+		int[] sections = get_majority_green(3, frame);
+
+		int section = 0;
+		int section_size = 0;
+		
+		// Get section with most green
+		for (int i = 0; i < sections.length; ++i) {
+			if (sections[i] > section_size) {
+				section = i;
+				section_size = sections[i];
+			} 
+		}
+
+		System.out.println("Segment with the most green: " + section);
+
         saveBitmap(frame);
         frame.recycle(); // not strictly necessary, but helpful
+    }
+
+	/**
+     * Get the segment of camera containing the most green
+     */
+	private int[] get_majority_green(int segments, Bitmap frame) {
+        final BitmapFactory.Options options = new BitmapFactory.Options();
+
+        // Reduce the resolution of the bitmap image
+        options.inSampleSize = this.sampleSize;
+
+        // Get the image as a bitmap
+        Bitmap bmp = BitmapFactory.decodeResource(getResources(), R.drawable.image, options);
+
+        // Get the image dimensions
+        int imageHeight = bmp.getHeight();
+        int imageWidth = bmp.getWidth();
+
+        // Divide the image into segments
+        int segment_length = imageWidth / segments;
+
+        // Array containing the total number of green pixels in a segment
+        int[] averages = new int[segments];
+
+        for (int x = 0; x < imageWidth; x++) {
+            for (int y = 0; y < imageHeight; y++) {
+
+                // Get pixel at x, y coordinate
+                int pixel = bmp.getPixel(x, y);
+
+                // Get RGB values from hex
+                int r = pixel & 0xff;
+                int g = (pixel >> 8) & 0xff;
+                int b = (pixel >> 16) & 0xff;
+
+                // Get index in array
+                int index = x / segment_length;
+
+                // If pixel is green, add to array
+                if (g >= r && g >= b && index < segments) averages[index] += 1;
+            }
+        }
+
+        return averages;
     }
 
     //----------------------------------------------------------------------------------------------

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Utilities/ConceptWebcam.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Utilities/ConceptWebcam.java
@@ -90,7 +90,7 @@ public class ConceptWebcam extends LinearOpMode {
 	/**
 	 * Sample size of the bitmap image, used to reduce computation time.
 	 * Large numbers decrease image quality.
-	 */
+	*/
 	private int sampleSize = 4;
 
     /**
@@ -185,7 +185,7 @@ public class ConceptWebcam extends LinearOpMode {
 
 		int section = 0;
 		int section_size = 0;
-		
+
 		// Get section with most green
 		for (int i = 0; i < sections.length; ++i) {
 			if (sections[i] > section_size) {
@@ -204,44 +204,44 @@ public class ConceptWebcam extends LinearOpMode {
      * Get the segment of camera containing the most green
      */
 	private int[] get_majority_green(int segments, Bitmap frame) {
-        final BitmapFactory.Options options = new BitmapFactory.Options();
+		final BitmapFactory.Options options = new BitmapFactory.Options();
 
-        // Reduce the resolution of the bitmap image
-        options.inSampleSize = this.sampleSize;
+		// Reduce the resolution of the bitmap image
+		options.inSampleSize = this.sampleSize;
 
-        // Get the image as a bitmap
-        Bitmap bmp = BitmapFactory.decodeResource(getResources(), R.drawable.image, options);
+		// Get the image as a bitmap
+		Bitmap bmp = BitmapFactory.decodeResource(getResources(), R.drawable.image, options);
 
-        // Get the image dimensions
-        int imageHeight = bmp.getHeight();
-        int imageWidth = bmp.getWidth();
+		// Get the image dimensions
+		int imageHeight = bmp.getHeight();
+		int imageWidth = bmp.getWidth();
 
-        // Divide the image into segments
-        int segment_length = imageWidth / segments;
+		// Divide the image into segments
+		int segment_length = imageWidth / segments;
 
-        // Array containing the total number of green pixels in a segment
-        int[] averages = new int[segments];
+		// Array containing the total number of green pixels in a segment
+		int[] averages = new int[segments];
 
-        for (int x = 0; x < imageWidth; x++) {
-            for (int y = 0; y < imageHeight; y++) {
+		for (int x = 0; x < imageWidth; x++) {
+			for (int y = 0; y < imageHeight; y++) {
 
-                // Get pixel at x, y coordinate
-                int pixel = bmp.getPixel(x, y);
+				// Get pixel at x, y coordinate
+				int pixel = bmp.getPixel(x, y);
 
-                // Get RGB values from hex
-                int r = pixel & 0xff;
-                int g = (pixel >> 8) & 0xff;
-                int b = (pixel >> 16) & 0xff;
+				// Get RGB values from hex
+				int r = pixel & 0xff;
+				int g = (pixel >> 8) & 0xff;
+				int b = (pixel >> 16) & 0xff;
 
-                // Get index in array
-                int index = x / segment_length;
+				// Get index in array
+				int index = x / segment_length;
 
-                // If pixel is green, add to array
-                if (g >= r && g >= b && index < segments) averages[index] += 1;
-            }
-        }
+				// If pixel is green, add to array
+				if (g >= r && g >= b && index < segments) averages[index] += 1;
+			}
+		}
 
-        return averages;
+		return averages;
     }
 
     //----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Added code to the onNewFrame method which divides the image into three sections and finds the section with the most green pixels. 

TODO
- [ ] Update webcam name 
- [ ] Output the result in a meaningful way (currently just prints to console)


